### PR TITLE
Add trailing new line to compiled output

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,11 @@ ES6to5Compiler.prototype.compile = function (params, callback) {
     return callback(err);
   }
   var result = {data: compiled.code || compiled};
+
+  // Concatenation is broken by trailing comments in files, which occur
+  // frequently when comment nodes are lost in the AST from 6to5.
+  result.data += '\n';
+
   if (compiled.map) result.map = JSON.stringify(compiled.map);
   callback(null, result);
 };


### PR DESCRIPTION
Brunch was getting confused for me because 6to5 will move comments to the last line of a file when their position is lost in the AST.