### PR TITLE
Support custom file extensions (through patterns)

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,9 @@ function ES6to5Compiler(config) {
   }, this);
   this.options.sourceMap = !!config.sourceMaps;
   this.isIgnored = anymatch(options.ignore || /^(bower_components|vendor)/);
+  if (this.options.pattern) {
+    this.pattern = this.options.pattern;
+  }
 }
 
 ES6to5Compiler.prototype.brunchPlugin = true;

--- a/test.js
+++ b/test.js
@@ -30,6 +30,37 @@ describe('Plugin', function() {
     });
   });
 
+  describe('custom file extensions & patterns', function() {
+
+    var basicPlugin = new Plugin({
+      pattern: /\.(babel|es6|jsx)$/
+    });
+    var sourceMapPlugin = new Plugin({
+      pattern: /\.(babel|es6|jsx)$/,
+      sourceMaps: true
+    });
+    var content = 'let a = 1';
+    var path = 'file.es6'
+
+    it('should handle basic compilationcustom file extensions', function(done) {
+      basicPlugin.compile({data: content, path: path}, function(error, result) {
+        assert(!error);
+        done();
+      });
+    });
+
+    it('should properly link to source file in source maps', function(done) {
+      sourceMapPlugin.compile({data: content, path: path}, function(error, result) {
+        assert(!error);
+        assert.doesNotThrow(function(){JSON.parse(result.map);});
+        assert.equal(JSON.parse(result.map).sources.indexOf(path) !== -1, true);
+        done();
+      })
+    })
+
+  });
+
+
   it('should produce source maps', function(done) {
     plugin = new Plugin({sourceMaps: true});
 


### PR DESCRIPTION
/reference https://github.com/babel/babel-brunch/issues/7

Adds support for the `pattern` attribute provided to brunch plugins. This allows `babel-brunch` to support any number of file extensions, because we're the Javascript community and we can't decide on anything :smile: 