### PR TITLE
updated property name for babel

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ compiling every `.js` file.
 
 ```coffee
 plugins:
-	babel:
+	ESbabel:
 		whitelist: ['arrowFunctions']
 		format:
 			semicolons: false


### PR DESCRIPTION
Looks like babel updated their config name for brunch to ESbabel, this worked for me, the older didn't. 