### PR TITLE
Update to babel v6 which should close #16.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: node_js
 node_js:
   - 'iojs'

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Set [babel options](https://babeljs.io/docs/usage/options) in your brunch
 config (such as `brunch-config.coffee`) except for `filename` and `sourceMap`
 which are handled internally.
 
+This plugin uses, by default, the
+[es2015](http://babeljs.io/docs/plugins/preset-es2015/) preset. To use no
+preset, then set the configuration option to an empty array.
+
 Additionally, you can set an `ignore` value to specify which `.js` files in
 your project should not be compiled by babel. By default, `ignore` is set to
 `/^(bower_components|vendor)/`.
@@ -26,15 +30,13 @@ compiling every `.js` file.
 
 ```coffee
 plugins:
-	babel:
-		whitelist: ['arrowFunctions']
-		format:
-			semicolons: false
-		ignore: [
-			/^(bower_components|vendor)/
-			'app/legacyES5Code/**/*'
-		]
-		pattern: /\.(es6|jsx)$/
+  babel:
+    presets: ['es2015']
+    ignore: [
+      /^(bower_components|vendor)/
+      'app/legacyES5Code/**/*'
+    ]
+    pattern: /\.(es6|jsx)$/
 ```
 
 Change Log

--- a/index.js
+++ b/index.js
@@ -18,6 +18,10 @@ function BabelCompiler(config) {
     this.pattern = this.options.pattern;
     delete this.options.pattern;
   }
+  this.options.presets = this.options.presets || ['es2015'];
+  if (this.options.presets.length === 0) {
+    delete this.options.presets;
+  }
 }
 
 BabelCompiler.prototype.brunchPlugin = true;

--- a/package.json
+++ b/package.json
@@ -22,10 +22,12 @@
     "test": "mocha"
   },
   "dependencies": {
-    "babel-core": "^5.0.0",
-    "anymatch": "^1.0.0"
+    "babel-core": "^6.0.0",
+    "anymatch": "^1.0.0",
+    "babel-preset-es2015": "^6.0.0"
   },
   "devDependencies": {
-    "mocha": "1.x"
+    "babel-plugin-transform-node-env-inline": "^6.1.18",
+    "mocha": "^2.0.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -6,6 +6,7 @@ var Plugin = require('./');
 
 describe('Plugin', function() {
   var plugin;
+  this.timeout(10000);
 
   beforeEach(function() {
     plugin = new Plugin({});
@@ -19,7 +20,20 @@ describe('Plugin', function() {
     assert.equal(typeof plugin.compile, 'function');
   });
 
+  it('should do nothing for no preset', function (done) {
+    var content = 'var c = {};\nvar { a, b } = c;';
+
+    plugin = new Plugin({ plugins: { babel: { presets: [] }}});
+    plugin.compile({data: content, path: 'file.js'}, function (error, result) {
+      assert(!error);
+      assert(result.data.indexOf(content) !== -1);
+      done();
+    });
+  });
+
   it('should compile and produce valid result', function(done) {
+    this.timeout(10000);
+
     var content = 'var c = {};\nvar {a, b} = c;';
     var expected = 'var a = c.a;\nvar b = c.b;';
 
@@ -30,8 +44,19 @@ describe('Plugin', function() {
     });
   });
 
-  describe('custom file extensions & patterns', function() {
+  it('should load indicated plugins', function(done) {
+    var content = 'var c = () => process.env.NODE_ENV;';
+    var expected = '"use strict";\n\nvar c = function c() {\n  return undefined;\n};';
 
+    plugin = new Plugin({ plugins: { babel: { plugins: ['transform-node-env-inline'] }}});
+    plugin.compile({data: content, path: 'file.js'}, function(error, result) {
+      assert(!error);
+      assert(result.data.indexOf(expected) !== -1);
+      done();
+    });
+  });
+
+  describe('custom file extensions & patterns', function() {
     var basicPlugin = new Plugin({
       plugins: {
         babel: {


### PR DESCRIPTION
Updated babel-core to "^6.0.0" and included the `es2015` preset as that would probably be the most popular setting.

Added two tests, one to ensure that the consumer of the plugin can override it as well as load other babel plugins.