### PR TITLE
Preserve folder structure for source-mapped files.

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ class BabelCompiler {
   compile(params) {
     if (this.isIgnored(params.path)) return Promise.resolve(params);
     this.options.filename = params.path;
+    this.options.sourceFileName = params.path;
 
     return new Promise((resolve, reject) => {
       let compiled;


### PR DESCRIPTION
Currently the path information other than the filename is lost from the sourcemaps which makes it difficult to work with them. This change sets the correct path for the source maps.