### PR TITLE
Ignore everything from 'node_modules'

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const babel = require('babel-core');
 const anymatch = require('anymatch');
 
-const reIg = /^(bower_components|node_modules\/[.-\w]-brunch|vendor)/;
+const reIg = /^(bower_components|node_modules|vendor)/;
 const reJsx = /\.(es6|jsx|js)$/;
 
 class BabelCompiler {


### PR DESCRIPTION
Probably a slightly better default since npm 3 sometimes won't create multiple levels of nesting and handlebars can end up being in `node_modules/handlebars`, not `node_modules/handlebars-brunch/node_modules/handlebars`