### PR TITLE
Allow babel-brunch to handle node_modules/

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const babel = require('babel-core');
 const anymatch = require('anymatch');
 
-const reIg = /^(bower_components|node_modules|vendor)/;
+const reIg = /^(bower_components|vendor)/;
 const reJsx = /\.(es6|jsx|js)$/;
 
 class BabelCompiler {
@@ -19,7 +19,11 @@ class BabelCompiler {
     }, {});
     opts.sourceMap = !!config.sourceMaps;
     if (!opts.presets) opts.presets = ['es2015'];
-    if (opts.presets.indexOf('react') !== -1) this.pattern = reJsx;
+    const origPresets = opts.presets;
+    // this is needed so that babel can locate presets when compiling node_modules
+    const mappedPresets = opts.presets.map(ps => require('path').resolve(config.paths.root, 'node_modules', `babel-preset-${ps}`));
+    opts.presets = mappedPresets;
+    if (origPresets.indexOf('react') !== -1) this.pattern = reJsx;
     if (opts.presets.length === 0) delete opts.presets;
     if (opts.pattern) {
       this.pattern = opts.pattern;

--- a/test.js
+++ b/test.js
@@ -9,7 +9,7 @@ describe('Plugin', function() {
   this.timeout(10000);
 
   beforeEach(function() {
-    plugin = new Plugin({});
+    plugin = new Plugin({ paths: { root: '.' }});
   });
 
   it('should be an object', function() {
@@ -23,7 +23,7 @@ describe('Plugin', function() {
   it('should do nothing for no preset', function (done) {
     var content = 'var c = {};\nvar { a, b } = c;';
 
-    plugin = new Plugin({ plugins: { babel: { presets: [] }}});
+    plugin = new Plugin({ paths: { root: '.' }, plugins: { babel: { presets: [] }}});
     plugin.compile({data: content, path: 'file.js'}).then(result => {
       assert(result.data.indexOf(content) !== -1);
       done();
@@ -44,7 +44,7 @@ describe('Plugin', function() {
     var content = 'var c = () => process.env.NODE_ENV;';
     var expected = '"use strict";\n\nvar c = function c() {\n  return undefined;\n};';
 
-    plugin = new Plugin({ plugins: { babel: { plugins: ['transform-node-env-inline'] }}});
+    plugin = new Plugin({ paths: { root: '.' }, plugins: { babel: { plugins: ['transform-node-env-inline'] }}});
     plugin.compile({data: content, path: 'file.js'}).then(result => {
       assert(result.data.indexOf(expected) !== -1);
       done();
@@ -53,6 +53,7 @@ describe('Plugin', function() {
 
   describe('custom file extensions & patterns', function() {
     var basicPlugin = new Plugin({
+      paths: { root: '.' },
       plugins: {
         babel: {
           pattern: /\.(babel|es6|jsx)$/
@@ -60,6 +61,7 @@ describe('Plugin', function() {
       }
     });
     var sourceMapPlugin = new Plugin({
+      paths: { root: '.' },
       plugins: {
         babel: {
           pattern: /\.(babel|es6|jsx)$/,
@@ -86,7 +88,7 @@ describe('Plugin', function() {
 
 
   it('should produce source maps', function(done) {
-    plugin = new Plugin({sourceMaps: true});
+    plugin = new Plugin({paths: { root: '.' }, sourceMaps: true});
 
     var content = 'let a = 1';
 


### PR DESCRIPTION
This is going to be needed in order to compile ES6 npm modules