### PR TITLE
Fix error messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const reJsx = /\.(es6|jsx|js)$/;
 
 const prettySyntaxError = (err) => {
   if (err._babel && err instanceof SyntaxError) {
-    return `${err.name}: ${err.message}\n${err.codeFrame}`;
+    return new Error(`${err.name}: ${err.message}\n${err.codeFrame}`);
   } else {
     return err;
   }


### PR DESCRIPTION
Before:

    11 Nov 07:51:28 - error: Compiling of test.js failed.

After:

    11 Nov 07:53:03 - error: Compiling of test.js failed. SyntaxError: test.js: super() outside of class constructor (163:4)
      161 |
      162 |   setupMap() {
    > 163 |     super().done(() => {
          |     ^
      164 |       this.map.addListener('click', () => {
      165 |         this.$storeSearch.blur()
      166 |       })

Fixes brunch/brunch#1555.