### PR TITLE
Fix for brunch/brunch#1549.

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,9 +32,12 @@ class BabelCompiler {
     const origPresets = opts.presets;
     // this is needed so that babel can locate presets when compiling node_modules
     const mapOption = type => data => {
-      const resolvePath = name => (
-        resolve(config.paths.root, 'node_modules', `babel-${type}-${name}`)
-      );
+      const resolvePath = name => {
+        // for cases when plugins name do not match common convention
+        // for example: `babel-root-import`
+        const plugin = name.startsWith('babel-') ? name : `babel-${type}-${name}`;
+        return resolve(config.paths.root, 'node_modules', plugin);
+      };
       if (typeof data === 'string') return resolvePath(data);
       return [resolvePath(data[0]), data[1]];
     };


### PR DESCRIPTION
Find plugins with names that do not match common convention.

For example: `babel-root-import`

---

Related:

* https://github.com/brunch/brunch/issues/1549
* https://github.com/michaelzoidl/babel-root-import/issues/63
