### PR TITLE
Update tests to actuall behavior

### DIFF
--- a/test.js
+++ b/test.js
@@ -32,7 +32,7 @@ describe('Plugin', function() {
 
   it('should compile and produce valid result', function(done) {
     var content = 'var c = {};\nvar {a, b} = c;';
-    var expected = 'var a = c.a;\nvar b = c.b;';
+    var expected = 'var a = c.a,\n    b = c.b;';
 
     plugin.compile({data: content, path: 'file.js'}).then(result => {
       assert(result.data.indexOf(expected) !== -1);


### PR DESCRIPTION
Related to: https://github.com/babel/babel-brunch/pull/45#issuecomment-269006540

Fix problem with single-var notation:


**Expected:**

```js
var a = c.a;
var b = c.b;
```

But got **actual:**

```js
"use strict";

var c = {};
var a = c.a,
    b = c.b;
```