### PR TITLE
Fix bugs when using .babelrc,  and babel option in package.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const logger = require('loggy');
 const reIg = /^(bower_components|vendor)/;
 
 const warns = {
-  emptyPresets: 'No plugins and presets is specified in brunch-config. If you are using .babelrc or `babel` option in your package.json please add `lookupConfigs` option to your brunch-config. Added es2015 and es2016 presets by default.',
+  emptyPresets: 'No plugins and presets is specified in brunch-config. If you are using .babelrc or `babel` option in your package.json please add `lookupConfigs: true` to your brunch-config. Added es2015 and es2016 presets by default.',
   ES6to5: 'Please use `babel` instead of `ES6to5` option in your config file.'
 }
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const logger = require('loggy');
 const reIg = /^(bower_components|vendor)/;
 
 const warns = {
-  emptyPresets: 'No plugins and presets was specified in brunch-config. If you are using .babelrc or `babel` option in your package.json please add `lookupConfigs` option to your brunch-config. Added es2015 and es2016 presets by default.',
+  emptyPresets: 'No plugins and presets is specified in brunch-config. If you are using .babelrc or `babel` option in your package.json please add `lookupConfigs` option to your brunch-config. Added es2015 and es2016 presets by default.',
   ES6to5: 'Please use `babel` instead of `ES6to5` option in your config file.'
 }
 

--- a/index.js
+++ b/index.js
@@ -29,15 +29,11 @@ const warnIf = (condition, warning) => {
 class BabelCompiler {
   constructor(config) {
     if (!config) config = {};
-    const rootPath = config.paths.root || '.';
-    const filename = resolve(rootPath, 'babelrc');
     const options = config.plugins &&
       (config.plugins.babel || config.plugins.ES6to5) || {};
     if (options && !config.plugins.babel) {
       warnIf(config.plugins.ES6to5, warns.ES6to5);
     }
-
-    options.filename = filename;
 
     const opts = Object.keys(options).reduce((obj, key) => {
       if (key !== 'sourceMap' && key !== 'ignore') {

--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ const babel = require('babel-core');
 const anymatch = require('anymatch');
 const resolve = require('path').resolve;
 
+const {OptionManager} = babel;
+
 const reIg = /^(bower_components|vendor)/;
 const reJsx = /\.(es6|jsx|js)$/;
 
@@ -18,14 +20,22 @@ const prettySyntaxError = (err) => {
 class BabelCompiler {
   constructor(config) {
     if (!config) config = {};
+    const optManager = new OptionManager;
+    const filename = './babelrc';
     const options = config.plugins &&
       (config.plugins.babel || config.plugins.ES6to5) || {};
-    const opts = Object.keys(options).reduce((obj, key) => {
+
+    options.filename = filename;
+
+    const mergedOptions = optManager.init(options);
+
+    const opts = Object.keys(mergedOptions).reduce((obj, key) => {
       if (key !== 'sourceMap' && key !== 'ignore') {
-        obj[key] = options[key];
+        obj[key] = mergedOptions[key];
       }
       return obj;
     }, {});
+    
     opts.sourceMap = !!config.sourceMaps;
     if (!opts.presets) opts.presets = ['es2015', 'es2016'];
     if (!opts.plugins) opts.plugins = [];

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "babel-core": "^6.0.0",
     "anymatch": "^1.0.0",
+    "loggy": "~0.3.3",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-es2016": "^6.11.0"
   },


### PR DESCRIPTION
This PR is intended to fix 2 issues:
1. For now, if you are ignoring presets option in `brunch-config` file or just set it as an empty array, babel-brunch will automatically set es2015, es2016 presets. It causes conflicts if you keep your babel config in *.babelrc* or `babel` option in *package.json* file.
2. babel-brunch ignore files with jsx/es6 extensions unless it finds **react** preset in presets from brunch-config. Again, if you are using configuration from .baberc/package.json even with react preset, plugin won't catch it and will observe only .js files.

Proposed solution:
1. Make `js/jsx/es6` pattern **static**.
2. **Remove default presets**. For now, many people can use babel-brunch without configuration with default presets and we must allow this enhancement only with `config.lookupConfigs = true` to prevent crashes . It would add the ability to use people *babelrc* and *package.json* configs, but must prevent other users' incomprehension.
3. If users are using plugin with empty babel configuration and without `lookupConfigs` option - warn them to add presets they need.
4. Warn people using `ES6to5` option and to change it to `babel`.

So after these changes, we will protect users from crashes and at the same time add the ability to use babelrc + pckg.json configuration normally by providing `lookupConfigs` option.