### PR TITLE
Env default

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,25 @@ Set [babel options](https://babeljs.io/docs/usage/options) in your brunch
 config (such as `brunch-config.js`) except for `filename` and `sourceMap`
 which are handled internally.
 
-This plugin uses, by default, the
-[es2015](https://babeljs.io/docs/plugins/preset-es2015/) and
-[es2016](https://babeljs.io/docs/plugins/preset-es2016/) presets. To use no
-preset, set the configuration option to an empty array.
+This plugin uses, by default,
+[babel-preset-env](https://github.com/babel/babel-preset-env/).
+To configure, use `env` option:
+
+```js
+plugins: {
+  babel: {
+    env: {
+      targets: {
+        safari 7, // explicitly
+        browsers: '>2%' // with browserslist query
+      }
+    }
+  }
+}
+```
+Without providing any options, behavior will be like using [babel-preset-latest](https://babeljs.io/docs/plugins/preset-latest/) (es2015, es2016, es2017).
+
+To use no preset, set the configuration option to an empty array.
 
 Additionally, you can set an `ignore` value to specify which `.js` files in
 your project should not be compiled by babel. By default, `ignore` is set to

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ plugins: {
   babel: {
     env: {
       targets: {
-        safari 7, // explicitly
+        safari: 7, // explicitly
         browsers: '>2%' // with browserslist query
       }
     }

--- a/index.js
+++ b/index.js
@@ -3,9 +3,13 @@
 const babel = require('babel-core');
 const anymatch = require('anymatch');
 const resolve = require('path').resolve;
+const logger = require('loggy');
 
 const reIg = /^(bower_components|vendor)/;
-const reJsx = /\.(es6|jsx|js)$/;
+
+const warns = {
+  ES6to5: 'Please use `babel` instead of `ES6to5` option in your config file.'
+};
 
 const prettySyntaxError = (err) => {
   if (err._babel && err instanceof SyntaxError) {
@@ -20,16 +24,23 @@ class BabelCompiler {
     if (!config) config = {};
     const options = config.plugins &&
       (config.plugins.babel || config.plugins.ES6to5) || {};
+    if (options && !config.plugins.babel && config.plugins.ES6to5) {
+      logger.warn(warns.ES6to5);
+    }
+
     const opts = Object.keys(options).reduce((obj, key) => {
       if (key !== 'sourceMap' && key !== 'ignore') {
         obj[key] = options[key];
       }
       return obj;
     }, {});
+
     opts.sourceMap = !!config.sourceMaps;
-    if (!opts.presets) opts.presets = ['es2015', 'es2016'];
+    if (!opts.presets || opts.presets.length === 0) {
+      opts.presets = [['env', opts.env]];
+    }
     if (!opts.plugins) opts.plugins = [];
-    const origPresets = opts.presets;
+
     // this is needed so that babel can locate presets when compiling node_modules
     const mapOption = type => data => {
       const resolvePath = name => {
@@ -45,7 +56,6 @@ class BabelCompiler {
     const mappedPlugins = opts.plugins.map(mapOption('plugin'));
     opts.presets = mappedPresets;
     opts.plugins = mappedPlugins;
-    if (origPresets.indexOf('react') !== -1) this.pattern = reJsx;
     if (opts.presets.length === 0) delete opts.presets;
     if (opts.plugins.length === 0) delete opts.plugins;
     if (opts.pattern) {
@@ -86,5 +96,6 @@ class BabelCompiler {
 BabelCompiler.prototype.brunchPlugin = true;
 BabelCompiler.prototype.type = 'javascript';
 BabelCompiler.prototype.extension = 'js';
+BabelCompiler.prototype.pattern = /\.(es6|jsx?)$/;
 
 module.exports = BabelCompiler;

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ class BabelCompiler {
     }, {});
 
     opts.sourceMap = !!config.sourceMaps;
-    if (!opts.presets || opts.presets.length === 0) {
+    if (!opts.presets) {
       opts.presets = [['env', opts.env]];
     }
     if (!opts.plugins) opts.plugins = [];

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   "dependencies": {
     "babel-core": "^6.0.0",
     "anymatch": "^1.0.0",
-    "babel-preset-es2015": "^6.9.0",
-    "babel-preset-es2016": "^6.11.0"
+    "loggy": "1.0.1",
+    "babel-preset-env": "^1.1.8"
   },
   "devDependencies": {
     "babel-plugin-transform-es2015-template-literals": "^6.8.0",


### PR DESCRIPTION
This PR includes 2. from https://github.com/babel/babel-brunch/pull/48
Also, it removes 'es2015' and 'es2016' presets from defaults in favor of https://github.com/babel/babel-preset-env. This solution wouldn't break anything for people who are using no configs and allow them to prevent writing all presets in `presets` array and just add `env` option to pick only plugins they needed. Without any specified target it works exactly like https://babeljs.io/docs/plugins/preset-latest/.

Possible config:

```js
plugins: {
  babel: {
    env: {
      targets: {
        safari 7, 
        browsers: '>2%'
      },
      useBuiltIns: true
    }
  }
}
```